### PR TITLE
Make plugin compatible with Python3 / Octoprint 1.4.0

### DIFF
--- a/octoprint_WifiSdSupport/__init__.py
+++ b/octoprint_WifiSdSupport/__init__.py
@@ -79,6 +79,7 @@ class WifisdsupportPlugin(octoprint.plugin.SettingsPlugin,
 # ("OctoPrint-PluginSkeleton"), you may define that here. Same goes for the other metadata derived from setup.py that
 # can be overwritten via __plugin_xyz__ control properties. See the documentation for that.
 __plugin_name__ = "WifiSdSupport Plugin"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
   global __plugin_implementation__

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_WifiSdSupport"
 plugin_name = "OctoPrint-WifiSdSupport"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.0"
+plugin_version = "0.1.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module
@@ -59,7 +59,9 @@ plugin_ignored_packages = []
 # Example:
 #     plugin_requires = ["someDependency==dev"]
 #     additional_setup_parameters = {"dependency_links": ["https://github.com/someUser/someRepo/archive/master.zip#egg=someDependency-dev"]}
-additional_setup_parameters = {}
+additional_setup_parameters = {
+    "use_2to3": True,
+}
 
 ########################################################################################################################
 


### PR DESCRIPTION
I have tested this on my OctoPrint instance running 1.4.0-RC3. I was not able to test it with the current Octoprint version (1.3), but I'm fairly confident it should still work.